### PR TITLE
Version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # CHANGELOG
 
+## 2.0.0
+
+## Added
+
+- `Get` and `Set` accept path as string instead of array
+
+## Fixed
+
+- `Get` and `Set` work correctly with union paths
+- `PathString` renamed to `StringToPath`
+
 ## 1.3.0
+
+### Fixed:
 
 - Get Performance and Recursion Depth Improvements ([#9](https://github.com/Ayub-Begimkulov/ts-get-set/pull/9))
 - Restructured a GetKey type to increase recursion depth for arrays ([#11](https://github.com/Ayub-Begimkulov/ts-get-set/pull/11))

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@ export { stringToPath } from "./string-to-path";
 
 export type { Get } from "./get";
 export type { Set } from "./set";
-export type { PathString } from "./string-to-path";
+export type { StringToPath } from "./string-to-path";

--- a/src/string-to-path.ts
+++ b/src/string-to-path.ts
@@ -1,16 +1,16 @@
-export type PathString<StringPath extends string> = PathString_<StringPath>;
+export type StringToPath<StringPath extends string> = StringToPath_<StringPath>;
 
-type PathString_<
+type StringToPath_<
   StringPath extends string,
   Path extends readonly string[] = []
 > = StringPath extends `${infer Key}.${infer Rest}`
-  ? PathString_<Rest, AppendPath<Path, Key>>
+  ? StringToPath_<Rest, AppendPath<Path, Key>>
   : AppendPath<Path, StringPath>;
 
 type AppendPath<
   Path extends readonly string[],
-  PathString extends string
-> = PathString extends "" ? Path : [...Path, PathString];
+  Item extends string
+> = Item extends "" ? Path : [...Path, Item];
 
 export const stringToPath = <T extends string>(path: T) =>
-  path.split(".").filter(Boolean) as PathString<T>;
+  path.split(".").filter(Boolean) as StringToPath<T>;

--- a/src/tuple.ts
+++ b/src/tuple.ts
@@ -1,23 +1,11 @@
-import { AnyArray, Depth } from "./types";
+import { AnyArray, Sequence } from "./types";
 
-// TODO do we not need a type distribution (i.e. `extends unknown`)?
-export type IsTuple<T extends AnyArray> = T extends unknown
-  ? number extends T["length"]
-    ? false
-    : true
-  : never;
-
-// export type IsTuple<Tuple extends AnyArray> = Tuple extends unknown
-//   ? Tuple extends []
-//     ? true
-//     : Tuple extends ReadonlyArray<infer U>
-//     ? U[] extends Tuple
-//       ? false
-//       : Tuple extends readonly [unknown, ...infer Rest] // edge case for types like `[1, 2, ...number[]]`
-//       ? IsTuple<Rest>
-//       : never
-//     : never
-//   : never;
+// Tuple arrays have literal indexes (e.g. 5)
+// we could use it to detect whether
+// array is tuple or not
+export type IsTuple<T extends AnyArray> = number extends T["length"]
+  ? false
+  : true;
 
 export type GetArrayValue<T extends AnyArray> = T extends ReadonlyArray<infer U>
   ? U
@@ -33,12 +21,12 @@ type SetTuple_<
   A extends AnyArray,
   Index extends string,
   Value,
-  Result extends unknown[] = []
+  Result extends AnyArray = []
 > = {
   0: A["length"] extends Result["length"]
     ? SetTuple_<A, Index, Value, [...Result, undefined]>
     : SetTuple_<A, Index, Value, [...Result, A[Result["length"]]]>;
-  1: [...Result, Value, ...GetTupleRest<A, Depth[Result["length"]]>]; // TODO add rest of `A`
+  1: [...Result, Value, ...GetTupleRest<A, Sequence[Result["length"]]>]; // TODO add rest of `A`
 }[`${Result["length"]}` extends Index ? 1 : 0];
 
 export type GetTupleRest<
@@ -51,13 +39,13 @@ type GetTupleRest_<
   Tuple extends AnyArray,
   Index extends number,
   Keys extends string,
-  Result extends unknown[] = []
+  Result extends AnyArray = []
 > =
   // if we are here, it means that on first run `Tuple["length"]` is higher than `Index`
   // otherwise the check wouldn't pass in `GetTupleRest`
   Tuple["length"] extends Index
     ? Result
-    : GetTupleRest_<Tuple, Depth[Index], Keys, [...Result, Tuple[Index]]>;
+    : GetTupleRest_<Tuple, Sequence[Index], Keys, [...Result, Tuple[Index]]>;
 
 // TODO dirty way (and most likely not effective from a performance perspective)
 // check if we can find other way

--- a/src/type-tests/get.test.types.ts
+++ b/src/type-tests/get.test.types.ts
@@ -2,49 +2,63 @@ import { get, Get } from "../get";
 import { assert, Equals } from ".";
 
 // simple
-assert<Equals<Get<{ a: 5 }, ["a"]>, 5>>(true);
+assert<Equals<Get<{ a: 5 }, "a">, 5>>(true);
 
 // arrays
-assert<Equals<Get<[1, 2, 3], ["2"]>, 3>>(true);
+assert<Equals<Get<[1, 2, 3], "2">, 3>>(true);
 
 // mixed
-assert<
-  Equals<Get<{ a: [1, { b: ["a", "b"] }, 3] }, ["a", "1", "b", "1"]>, "b">
->(true);
+assert<Equals<Get<{ a: [1, { b: ["a", "b"] }, 3] }, "a.1.b.1">, "b">>(true);
 
 // wrong path
-assert<Equals<Get<{ a: 5 }, ["b"]>, undefined>>(true);
+assert<Equals<Get<{ a: 5 }, "b">, undefined>>(true);
 
 // default value
-assert<Equals<Get<{ a: 5 }, ["b"], "asdf">, "asdf">>(true);
+assert<Equals<Get<{ a: 5 }, "b", "asdf">, "asdf">>(true);
 
 // default value with undefined
-assert<Equals<Get<{ a: 5; b: undefined }, ["b"], "asdf">, "asdf">>(true);
+assert<Equals<Get<{ a: 5; b: undefined }, "b", "asdf">, "asdf">>(true);
 
 // default value with undefined in union
 assert<
-  Equals<Get<{ a: 5; b: number | undefined }, ["b"], "asdf">, number | "asdf">
+  Equals<Get<{ a: 5; b: number | undefined }, "b", "asdf">, number | "asdf">
 >(true);
 
 // should work with unions correctly
-assert<Equals<Get<{ a: number } | { a: string }, ["a"]>, string | number>>(
+// union objects
+assert<Equals<Get<{ a: number } | { a: string }, "a">, string | number>>(true);
+
+// union arrays
+assert<Equals<Get<{ a: { "2": "hello" } | [1, 2, 3] }, "a.2">, 3 | "hello">>(
   true
 );
 
+// union path
 assert<
-  Equals<Get<{ a: { "2": "hello" } | [1, 2, 3] }, ["a", "2"]>, 3 | "hello">
+  Equals<Get<{ a: number; b: { c: string } }, "a" | "b.c">, string | number>
+>(true);
+
+// union path and value
+assert<
+  Equals<
+    Get<
+      { a: number; b: { c: string } } | { a: symbol; b: { c: boolean } },
+      "a" | "b.c"
+    >,
+    string | number | symbol | boolean
+  >
 >(true);
 
 // should add undefined if one of union types is primitive
-assert<Equals<Get<{ a: number | [1, 2, 3] }, ["a", "2"]>, 3 | undefined>>(true);
+assert<Equals<Get<{ a: number | [1, 2, 3] }, "a.2">, 3 | undefined>>(true);
 
 // union type should add undefined for arrays (noUncheckIndexAccess)
-assert<Equals<Get<{ a: number[] }, ["a", "2"]>, number | undefined>>(true);
+assert<Equals<Get<{ a: number[] }, "a.2">, number | undefined>>(true);
 
 // regular arrays, primitive union
 assert<
   Equals<
-    Get<{ a: (number | { b: number })[] }, ["a", "2"]>,
+    Get<{ a: (number | { b: number })[] }, "a.2">,
     number | { b: number } | undefined
   >
 >(true);

--- a/src/type-tests/set.test.types.ts
+++ b/src/type-tests/set.test.types.ts
@@ -1,23 +1,20 @@
 import { assert, Equals } from ".";
-import { Set } from "../set";
+import { set, Set } from "../set";
 
 // simple
-assert<Equals<Set<{ a: number }, ["a"], string>, { a: string }>>(true);
+assert<Equals<Set<{ a: number }, "a", string>, { a: string }>>(true);
 
 // nested
-assert<
-  Equals<Set<{ a: { b: number } }, ["a", "b"], string>, { a: { b: string } }>
->(true);
+assert<Equals<Set<{ a: { b: number } }, "a.b", string>, { a: { b: string } }>>(
+  true
+);
 
 // simple arrays
-assert<Equals<Set<[1, 2, 3], ["1"], 4>, [1, 4, 3]>>(true);
+assert<Equals<Set<[1, 2, 3], "1", 4>, [1, 4, 3]>>(true);
 
 // mixed (objects and arrays)
 assert<
-  Equals<
-    Set<{ a: { b: [1, 2, 3] } }, ["a", "b", "1"], 4>,
-    { a: { b: [1, 4, 3] } }
-  >
+  Equals<Set<{ a: { b: [1, 2, 3] } }, "a.b.1", 4>, { a: { b: [1, 4, 3] } }>
 >(true);
 
 // should change value if not object
@@ -26,7 +23,7 @@ type TestObject = {
   b: { c: number };
 };
 
-type TestPath = ["b", "c", "1"];
+type TestPath = "b.c.1";
 
 assert<
   Equals<
@@ -40,37 +37,36 @@ assert<
   >
 >(true);
 
+// should return the same object if empty path
+assert<Equals<Set<{ a: number }, "", string>, { a: number }>>(true);
+
 // should create objects if they are not present
-assert<Equals<Set<{}, ["a", "b"], 1>, { a: { b: 1 } }>>(true);
+assert<Equals<Set<{}, "a.b", 1>, { a: { b: 1 } }>>(true);
 
 // should create arrays if they are not present
-assert<Equals<Set<[], ["1", "2"], 1>, [undefined, [undefined, undefined, 1]]>>(
-  true
-);
+assert<Equals<Set<[], "1.2", 1>, [undefined, [undefined, undefined, 1]]>>(true);
 
 // array but key is not array'ish
-assert<Equals<Set<[1, 2, 3], ["a", "b"], 5>, [1, 2, 3] & { a: { b: 5 } }>>(
-  true
-);
+assert<Equals<Set<[1, 2, 3], "a.b", 5>, [1, 2, 3] & { a: { b: 5 } }>>(true);
 
 // array but key is not array'ish with readonly
 assert<
   Equals<
-    Set<readonly [1, 2, 3], ["a", "b"], 5>,
+    Set<readonly [1, 2, 3], "a.b", 5>,
     readonly [1, 2, 3] & { a: { b: 5 } }
   >
 >(true);
 
 // not tuple arrays - change type
-assert<
-  Equals<Set<{ a: number[] }, ["a", "2"], "asdf">, { a: (number | "asdf")[] }>
->(true);
+assert<Equals<Set<{ a: number[] }, "a.2", "asdf">, { a: (number | "asdf")[] }>>(
+  true
+);
 
 // should work with unions correctly
 // union objects
 assert<
   Equals<
-    Set<{ a: string } | { b: number }, ["a"], boolean>,
+    Set<{ a: string } | { b: number }, "a", boolean>,
     | {
         a: boolean;
       }
@@ -84,7 +80,7 @@ assert<
 // union arrays
 assert<
   Equals<
-    Set<["asdf", "fdsa"] | [1, 2, 3], ["2"], false>,
+    Set<["asdf", "fdsa"] | [1, 2, 3], "2", false>,
     ["asdf", "fdsa", false] | [1, 2, false]
   >
 >(true);
@@ -92,11 +88,71 @@ assert<
 // union with primitive
 assert<
   Equals<
-    Set<{ a: ["asdf", "fdsa"] | boolean }, ["a", "2"], false>,
+    Set<{ a: ["asdf", "fdsa"] | boolean }, "a.2", false>,
     { a: ["asdf", "fdsa", false] | [undefined, undefined, false] }
   >
 >(true);
 
+// union path
+assert<
+  Equals<
+    Set<{ a: number; b: { c: string } }, "a" | "b.c", "value">,
+    { a: "value"; b: { c: string } } | { a: number; b: { c: "value" } }
+  >
+>(true);
+
+// union with union object path
+assert<
+  Equals<
+    Set<
+      { a: number; b: { c: string } } | { prop: false },
+      "a" | "b.c",
+      "value"
+    >,
+    | { a: "value"; b: { c: string } }
+    | { a: number; b: { c: "value" } }
+    | { prop: false; a: "value" }
+    | { prop: false; b: { c: "value" } }
+  >
+>(true);
+
+// depth test array
+set([[[[[[[[0]]]]]]]], "0.0.0.0.0.0.0", 5);
+
+// depth test object
+set(
+  {
+    a: {
+      b: {
+        c: {
+          d: {
+            e: {
+              f: {
+                g: {
+                  h: {
+                    i: {
+                      j: {
+                        k: {
+                          l: {
+                            m: {
+                              n: { o: { p: 5 } },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p",
+  5
+);
 // TODO do we need to preserve readonly when using set?
 // assert<
 //   Equals<

--- a/src/type-tests/string-to-path.test.types.ts
+++ b/src/type-tests/string-to-path.test.types.ts
@@ -1,17 +1,17 @@
 import { assert, Equals } from "./index";
-import { PathString } from "../index";
+import { StringToPath } from "../index";
 
 // basic
-assert<Equals<PathString<"a.b.c.1.d">, ["a", "b", "c", "1", "d"]>>(true);
+assert<Equals<StringToPath<"a.b.c.1.d">, ["a", "b", "c", "1", "d"]>>(true);
 
 // empty
-assert<Equals<PathString<"">, []>>(true);
+assert<Equals<StringToPath<"">, []>>(true);
 
 // empty start
-assert<Equals<PathString<".a.b.1">, ["a", "b", "1"]>>(true);
+assert<Equals<StringToPath<".a.b.1">, ["a", "b", "1"]>>(true);
 
 // empty center
-assert<Equals<PathString<"a..b..1">, ["a", "b", "1"]>>(true);
+assert<Equals<StringToPath<"a..b..1">, ["a", "b", "1"]>>(true);
 
 // only dot
-assert<Equals<PathString<".">, []>>(true);
+assert<Equals<StringToPath<".">, []>>(true);

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export interface AnyObject {
 
 export interface AnyArray extends ReadonlyArray<unknown> {}
 
-export type Depth = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+export type Sequence = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
 export type IsNumericKey<T extends string> = T extends `${number}`
   ? true


### PR DESCRIPTION
`Get` and `Set` accept a string as a path and works correctly with union paths.